### PR TITLE
Support JDK 19's Thread/sleep

### DIFF
--- a/11/playsync/src/playsync/core.clj
+++ b/11/playsync/src/playsync/core.clj
@@ -34,7 +34,7 @@
 
 (defn upload
   [headshot c]
-  (go (Thread/sleep (rand 100))
+  (go (Thread/sleep (long (rand 100)))
       (>! c headshot)))
 
 


### PR DESCRIPTION
JDK 19 doesn't like this:
```
(Thread/sleep (rand 100))
;Execution error (IllegalArgumentException) at async-alts.core/eval11621 (form-init13060262411934958877.clj:1).
;No matching method sleep found taking 1 args
```

There is a new method that Clojure can't disambiguate: https://docs.oracle.com/en/java/javase/19/docs/api/java.base/java/lang/Thread.html#sleep(java.time.Duration)